### PR TITLE
Use r-lib standard CI workflow (resolves #124)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,26 +2,78 @@ name: check
 
 on:
   push:
-    branches: 
+    branches:
       - master
-      - refactor
   pull_request:
-    branches: 
+    branches:
       - master
-      - refactor
-    
 
 jobs:
   R-CMD-check:
-    runs-on: macOS-latest
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: windows-latest, r: 'release'}
+          - {os: macOS-latest, r: 'release'}
+          - {os: ubuntu-18.04, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
+          - {os: ubuntu-18.04, r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
+
+    env:
+      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+      RSPM: ${{ matrix.config.rspm }}
+
     steps:
       - uses: actions/checkout@v2
+
       - uses: r-lib/actions/setup-r@master
+        with:
+          r-version: ${{ matrix.config.r }}
+
+      - uses: r-lib/actions/setup-pandoc@master
+
+      - name: Query dependencies
+        run: |
+          install.packages('remotes')
+          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+        shell: Rscript {0}
+
+      - name: Cache R packages
+        if: runner.os != 'Windows'
+        uses: actions/cache@v1
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+
+      - name: Install system dependencies
+        if: runner.os == 'Linux'
+        run: |
+          while read -r cmd
+          do
+            eval sudo $cmd
+          done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "18.04"), sep = "\n")')
+
       - name: Install dependencies
         run: |
-          install.packages(c("remotes", "devtools"))
           remotes::install_deps(dependencies = TRUE)
+          remotes::install_cran("rcmdcheck")
         shell: Rscript {0}
+
       - name: Check
-        run: devtools::check(force_suggests = TRUE)
+        env:
+          _R_CHECK_CRAN_INCOMING_REMOTE_: false
+        run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
         shell: Rscript {0}
+
+      - name: Upload check results
+        if: failure()
+        uses: actions/upload-artifact@main
+        with:
+          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
+          path: check

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -3,5 +3,5 @@ pkgdown: 1.5.1
 pkgdown_sha: ~
 articles:
   introduction: introduction.html
-last_built: 2020-07-29T18:30Z
+last_built: 2020-07-29T18:49Z
 

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -3,5 +3,5 @@ pkgdown: 1.5.1
 pkgdown_sha: ~
 articles:
   introduction: introduction.html
-last_built: 2020-07-29T18:49Z
+last_built: 2020-07-29T18:57Z
 

--- a/docs/reference/define_cv.html
+++ b/docs/reference/define_cv.html
@@ -210,8 +210,7 @@
 #&gt;     names(out) &lt;- c("ROC", "Sens", "Spec")
 #&gt;     out
 #&gt; }
-#&gt; &lt;bytecode: 0x7fc23e0597f8&gt;
-#&gt; &lt;bytecode: 0x7fe6b59057a0&gt;
+#&gt; &lt;bytecode: 0x7fe38585f3c0&gt;
 #&gt; &lt;environment: namespace:caret&gt;
 #&gt; 
 #&gt; $selectionFunction

--- a/docs/reference/define_cv.html
+++ b/docs/reference/define_cv.html
@@ -210,6 +210,7 @@
 #&gt;     names(out) &lt;- c("ROC", "Sens", "Spec")
 #&gt;     out
 #&gt; }
+#&gt; &lt;bytecode: 0x7fc23e0597f8&gt;
 #&gt; &lt;bytecode: 0x7fe6b59057a0&gt;
 #&gt; &lt;environment: namespace:caret&gt;
 #&gt; 


### PR DESCRIPTION
From https://github.com/r-lib/actions/tree/master/examples#standard-ci-workflow:

> This workflow runs R CMD check via the rcmdcheck package on the three major OSs (linux, macOS and Windows) with the current release version of R, and R-devel. If you plan to someday submit your package to CRAN or Bioconductor this is likely the workflow you want to use.