### PR TITLE
Temporary fix to make feature importance work with tibbles

### DIFF
--- a/R/feature_importance.R
+++ b/R/feature_importance.R
@@ -35,9 +35,12 @@ get_feature_importance <- function(trained_model, train_data, test_data, outcome
 
   grps <- group_correlated_features(corr_mat, features)
 
-  imps <- do.call("rbind", future.apply::future_lapply(grps, function(feat) {
-    return(find_permuted_perf_metric(test_data, trained_model, outcome_colname, perf_metric_function, perf_metric_name, class_probs, feat, seed))
-  }, future.seed = seed))
+  imps <- future.apply::future_lapply(grps, function(feat) {
+    return(find_permuted_perf_metric(test_data, trained_model, outcome_colname,
+                                     perf_metric_function, perf_metric_name,
+                                     class_probs, feat, seed))
+    }, future.seed = seed) %>%
+    dplyr::bind_rows()
 
   return(as.data.frame(imps) %>%
     dplyr::mutate(
@@ -60,11 +63,22 @@ get_feature_importance <- function(trained_model, train_data, test_data, outcome
 #' @noRd
 #' @author Begüm Topçuoğlu, \email{topcuoglu.begum@@gmail.com}
 #' @author Zena Lapp, \email{zenalapp@@umich.edu}
+#' @author Kelly Sovacool, \email{sovacool@@umich.edu}
 #'
 find_permuted_perf_metric <- function(test_data, trained_model, outcome_colname, perf_metric_function, perf_metric_name, class_probs, feat, seed) {
   abort_packages_not_installed("future.apply")
+
+  # The code below uses a bunch of base R subsetting that doesn't work with tibbles.
+  # We should probably refactor those to use tidyverse functions instead,
+  # but for now this is a temporary fix.
+  test_data <- as.data.frame(test_data)
+
   # Calculate the test performance metric for the actual pre-processed held-out data
-  test_perf_metric <- calc_perf_metrics(test_data, trained_model, outcome_colname, perf_metric_function, class_probs)[perf_metric_name]
+  test_perf_metric <- calc_perf_metrics(test_data,
+                                        trained_model,
+                                        outcome_colname,
+                                        perf_metric_function,
+                                        class_probs)[perf_metric_name]
   # permute grouped features together
   fs <- strsplit(feat, "\\|")[[1]]
   # only include ones in the test data split
@@ -79,7 +93,11 @@ find_permuted_perf_metric <- function(test_data, trained_model, outcome_colname,
       permuted_test_data[, fs] <- t(sample(data.frame(t(permuted_test_data[, fs]))))
     }
     # Calculate the new performance metric
-    new_perf_metric <- calc_perf_metrics(permuted_test_data, trained_model, outcome_colname, perf_metric_function, class_probs)[perf_metric_name]
+    new_perf_metric <- calc_perf_metrics(permuted_test_data,
+                                         trained_model,
+                                         outcome_colname,
+                                         perf_metric_function,
+                                         class_probs)[perf_metric_name]
     # Return how does this feature being permuted effect the performance metric
     return(c(new_perf_metric = new_perf_metric, diff = (test_perf_metric - new_perf_metric)))
   }, future.seed = seed)

--- a/R/feature_importance.R
+++ b/R/feature_importance.R
@@ -36,10 +36,12 @@ get_feature_importance <- function(trained_model, train_data, test_data, outcome
   grps <- group_correlated_features(corr_mat, features)
 
   imps <- future.apply::future_lapply(grps, function(feat) {
-    return(find_permuted_perf_metric(test_data, trained_model, outcome_colname,
-                                     perf_metric_function, perf_metric_name,
-                                     class_probs, feat, seed))
-    }, future.seed = seed) %>%
+    return(find_permuted_perf_metric(
+      test_data, trained_model, outcome_colname,
+      perf_metric_function, perf_metric_name,
+      class_probs, feat, seed
+    ))
+  }, future.seed = seed) %>%
     dplyr::bind_rows()
 
   return(as.data.frame(imps) %>%
@@ -74,11 +76,13 @@ find_permuted_perf_metric <- function(test_data, trained_model, outcome_colname,
   test_data <- as.data.frame(test_data)
 
   # Calculate the test performance metric for the actual pre-processed held-out data
-  test_perf_metric <- calc_perf_metrics(test_data,
-                                        trained_model,
-                                        outcome_colname,
-                                        perf_metric_function,
-                                        class_probs)[perf_metric_name]
+  test_perf_metric <- calc_perf_metrics(
+    test_data,
+    trained_model,
+    outcome_colname,
+    perf_metric_function,
+    class_probs
+  )[perf_metric_name]
   # permute grouped features together
   fs <- strsplit(feat, "\\|")[[1]]
   # only include ones in the test data split
@@ -93,11 +97,13 @@ find_permuted_perf_metric <- function(test_data, trained_model, outcome_colname,
       permuted_test_data[, fs] <- t(sample(data.frame(t(permuted_test_data[, fs]))))
     }
     # Calculate the new performance metric
-    new_perf_metric <- calc_perf_metrics(permuted_test_data,
-                                         trained_model,
-                                         outcome_colname,
-                                         perf_metric_function,
-                                         class_probs)[perf_metric_name]
+    new_perf_metric <- calc_perf_metrics(
+      permuted_test_data,
+      trained_model,
+      outcome_colname,
+      perf_metric_function,
+      class_probs
+    )[perf_metric_name]
     # Return how does this feature being permuted effect the performance metric
     return(c(new_perf_metric = new_perf_metric, diff = (test_perf_metric - new_perf_metric)))
   }, future.seed = seed)

--- a/R/run_ml.R
+++ b/R/run_ml.R
@@ -41,8 +41,6 @@
 #' @examples
 #' \dontrun{
 #' run_ml(otu_small, "glmnet",
-#'   kfold = 2,
-#'   cv_times = 2,
 #'   seed = 2019
 #' )
 #' }

--- a/man/get_feature_importance.Rd
+++ b/man/get_feature_importance.Rd
@@ -47,11 +47,11 @@ Calculates feature importance using a trained model and test data. Requires the 
 \examples{
 \dontrun{
 results <- run_ml(otu_small, "glmnet", kfold = 2, cv_times = 2)
-names(results$trained_model$trainingData)[1] <- 'dx'
-get_feature_importance(results$trained_model,results$trained_model$trainingData, results$test_data,
+names(results$trained_model$trainingData)[1] <- "dx"
+get_feature_importance(results$trained_model, results$trained_model$trainingData, results$test_data,
   "dx",
-  multiClassSummary, 'AUC',
-  class_probs = TRUE, method = 'glmnet'
+  multiClassSummary, "AUC",
+  class_probs = TRUE, method = "glmnet"
 )
 }
 

--- a/man/get_partition_indices.Rd
+++ b/man/get_partition_indices.Rd
@@ -30,7 +30,6 @@ partitions to be reproducible (recommended).
 training_inds <- get_partition_indices(otu_mini_bin$dx)
 train_data <- otu_mini_bin[training_inds, ]
 test_data <- otu_mini_bin[-training_inds, ]
-
 }
 \author{
 Kelly Sovacool, {sovacool@umich.edu}

--- a/man/get_performance_tbl.Rd
+++ b/man/get_performance_tbl.Rd
@@ -42,10 +42,10 @@ Get model performance metrics as a one-row tibble
 
 \dontrun{
 results <- run_ml(otu_small, "glmnet", kfold = 2, cv_times = 2)
-names(results$trained_model$trainingData)[1] <- 'dx'
-get_performance_tbl(results$trained_model,results$test_data,
+names(results$trained_model$trainingData)[1] <- "dx"
+get_performance_tbl(results$trained_model, results$test_data,
   "dx",
-  multiClassSummary, 'AUC',
+  multiClassSummary, "AUC",
   class_probs = TRUE
 )
 }

--- a/man/mikropml.Rd
+++ b/man/mikropml.Rd
@@ -22,14 +22,13 @@ running machine learning, and \code{run_ml()} to run machine learning.
 }
 }
 
-\section{See also}{
+\section{See vignettes}{
 
 \itemize{
-\item \href{http://www.schlosslab.org/mikropml/articles/}{All vignettes}.
-\item \href{http://www.schlosslab.org/mikropml/articles/introduction.html}{Intro vignette}.
-\item \href{http://www.schlosslab.org/mikropml/articles/parallel.html}{Parallel vignette} to make it run faster.
-\item \href{https://github.com/SchlossLab/mikropml-snakemake-workflow}{Snakemake workflow} for high-performance computing clusters.
-\item \href{http://www.schlosslab.org/mikropml/articles/paper.html}{The mikropml paper}.
+\item \href{http://www.schlosslab.org/mikropml/articles/introduction.html}{Introduction}
+\item \href{http://www.schlosslab.org/mikropml/articles/preprocess.html}{Preprocessing data}
+\item \href{http://www.schlosslab.org/mikropml/articles/parallel.html}{Parallel processing}
+\item \href{http://www.schlosslab.org/mikropml/articles/paper.html}{The mikropml paper}
 }
 }
 

--- a/man/otu_mini_bin.Rd
+++ b/man/otu_mini_bin.Rd
@@ -13,7 +13,8 @@ All other columns are OTU relative abundances.
 otu_mini_bin
 }
 \description{
-A dataset containing relatives abundances of OTUs for human stool samples.
+A dataset containing relatives abundances of OTUs for human stool samples
+with a binary outcome, \code{dx}.
 This is a subset of \code{otu_small}.
 }
 \keyword{datasets}

--- a/man/otu_mini_bin_results_glmnet.Rd
+++ b/man/otu_mini_bin_results_glmnet.Rd
@@ -3,7 +3,7 @@
 \docType{data}
 \name{otu_mini_bin_results_glmnet}
 \alias{otu_mini_bin_results_glmnet}
-\title{Results from running the pipline with L2 logistic regression on \code{otu_mini} with feature importance and grouping}
+\title{Results from running the pipline with L2 logistic regression on \code{otu_mini_bin} with feature importance and grouping}
 \format{
 An object of class \code{list} of length 4.
 }
@@ -11,6 +11,6 @@ An object of class \code{list} of length 4.
 otu_mini_bin_results_glmnet
 }
 \description{
-Results from running the pipline with L2 logistic regression on \code{otu_mini} with feature importance and grouping
+Results from running the pipline with L2 logistic regression on \code{otu_mini_bin} with feature importance and grouping
 }
 \keyword{datasets}

--- a/man/otu_mini_bin_results_rf.Rd
+++ b/man/otu_mini_bin_results_rf.Rd
@@ -3,7 +3,7 @@
 \docType{data}
 \name{otu_mini_bin_results_rf}
 \alias{otu_mini_bin_results_rf}
-\title{Results from running the pipline with random forest on \code{otu_mini}}
+\title{Results from running the pipline with random forest on \code{otu_mini_bin}}
 \format{
 An object of class \code{list} of length 4.
 }
@@ -11,6 +11,6 @@ An object of class \code{list} of length 4.
 otu_mini_bin_results_rf
 }
 \description{
-Results from running the pipline with random forest on \code{otu_mini}
+Results from running the pipline with random forest on \code{otu_mini_bin}
 }
 \keyword{datasets}

--- a/man/otu_mini_bin_results_rpart2.Rd
+++ b/man/otu_mini_bin_results_rpart2.Rd
@@ -3,7 +3,7 @@
 \docType{data}
 \name{otu_mini_bin_results_rpart2}
 \alias{otu_mini_bin_results_rpart2}
-\title{Results from running the pipline with rpart2 on \code{otu_mini}}
+\title{Results from running the pipline with rpart2 on \code{otu_mini_bin}}
 \format{
 An object of class \code{list} of length 4.
 }
@@ -11,6 +11,6 @@ An object of class \code{list} of length 4.
 otu_mini_bin_results_rpart2
 }
 \description{
-Results from running the pipline with rpart2 on \code{otu_mini}
+Results from running the pipline with rpart2 on \code{otu_mini_bin}
 }
 \keyword{datasets}

--- a/man/otu_mini_bin_results_svmRadial.Rd
+++ b/man/otu_mini_bin_results_svmRadial.Rd
@@ -3,7 +3,7 @@
 \docType{data}
 \name{otu_mini_bin_results_svmRadial}
 \alias{otu_mini_bin_results_svmRadial}
-\title{Results from running the pipline with svmRadial on \code{otu_mini}}
+\title{Results from running the pipline with svmRadial on \code{otu_mini_bin}}
 \format{
 An object of class \code{list} of length 4.
 }
@@ -11,6 +11,6 @@ An object of class \code{list} of length 4.
 otu_mini_bin_results_svmRadial
 }
 \description{
-Results from running the pipline with svmRadial on \code{otu_mini}
+Results from running the pipline with svmRadial on \code{otu_mini_bin}
 }
 \keyword{datasets}

--- a/man/otu_mini_bin_results_xgbTree.Rd
+++ b/man/otu_mini_bin_results_xgbTree.Rd
@@ -3,7 +3,7 @@
 \docType{data}
 \name{otu_mini_bin_results_xgbTree}
 \alias{otu_mini_bin_results_xgbTree}
-\title{Results from running the pipline with xbgTree on \code{otu_mini}}
+\title{Results from running the pipline with xbgTree on \code{otu_mini_bin}}
 \format{
 An object of class \code{list} of length 4.
 }
@@ -11,6 +11,6 @@ An object of class \code{list} of length 4.
 otu_mini_bin_results_xgbTree
 }
 \description{
-Results from running the pipline with xbgTree on \code{otu_mini}
+Results from running the pipline with xbgTree on \code{otu_mini_bin}
 }
 \keyword{datasets}

--- a/man/otu_mini_cont_results_glmnet.Rd
+++ b/man/otu_mini_cont_results_glmnet.Rd
@@ -3,7 +3,7 @@
 \docType{data}
 \name{otu_mini_cont_results_glmnet}
 \alias{otu_mini_cont_results_glmnet}
-\title{Results from running the pipeline with glmnet on \code{otu_mini} with \code{Otu00001} as the outcome}
+\title{Results from running the pipeline with glmnet on \code{otu_mini_bin} with \code{Otu00001} as the outcome}
 \format{
 An object of class \code{list} of length 4.
 }
@@ -11,6 +11,6 @@ An object of class \code{list} of length 4.
 otu_mini_cont_results_glmnet
 }
 \description{
-Results from running the pipeline with glmnet on \code{otu_mini} with \code{Otu00001} as the outcome
+Results from running the pipeline with glmnet on \code{otu_mini_bin} with \code{Otu00001} as the outcome
 }
 \keyword{datasets}

--- a/man/otu_mini_cv.Rd
+++ b/man/otu_mini_cv.Rd
@@ -3,7 +3,7 @@
 \docType{data}
 \name{otu_mini_cv}
 \alias{otu_mini_cv}
-\title{cross validation on \code{train_data_mini} with grouped features}
+\title{Cross validation on \code{train_data_mini} with grouped features.}
 \format{
 An object of class \code{list} of length 27.
 }
@@ -11,6 +11,6 @@ An object of class \code{list} of length 27.
 otu_mini_cv
 }
 \description{
-cross validation on \code{train_data_mini} with grouped features
+Cross validation on \code{train_data_mini} with grouped features.
 }
 \keyword{datasets}

--- a/man/preprocess_data.Rd
+++ b/man/preprocess_data.Rd
@@ -43,7 +43,8 @@ Function to preprocess your data for input into \code{\link[=run_ml]{run_ml()}}.
 \section{More details}{
 
 
-For more details, please see the \href{http://www.schlosslab.org/mikropml/articles/preprocess.html}{preprocessing vignette}.
+See the \href{http://www.schlosslab.org/mikropml/articles/preprocess.html}{preprocessing vignette}
+for more details.
 }
 
 \examples{

--- a/man/run_ml.Rd
+++ b/man/run_ml.Rd
@@ -77,8 +77,6 @@ For more details, please see the corresponding vignettes:
 \examples{
 \dontrun{
 run_ml(otu_small, "glmnet",
-  kfold = 2,
-  cv_times = 2,
   seed = 2019
 )
 }

--- a/tests/testthat/test-feature_importance.R
+++ b/tests/testthat/test-feature_importance.R
@@ -33,10 +33,10 @@ test_that("find_permuted_perf_metric works", {
   )
   expect_equal(
     find_permuted_perf_metric(otu_mini_bin_results_glmnet$test_data %>% dplyr::as_tibble(),
-                              otu_mini_bin_results_glmnet$trained_model,
-                              "dx", caret::multiClassSummary,
-                              "AUC", TRUE, "Otu00009",
-                              seed = 2019
+      otu_mini_bin_results_glmnet$trained_model,
+      "dx", caret::multiClassSummary,
+      "AUC", TRUE, "Otu00009",
+      seed = 2019
     ),
     c(perf_metric = 0.639105263, perf_metric_diff = 0.008263158),
     tol = 10e-5

--- a/tests/testthat/test-feature_importance.R
+++ b/tests/testthat/test-feature_importance.R
@@ -31,7 +31,48 @@ test_that("find_permuted_perf_metric works", {
     c(perf_metric = 0.6473684, perf_metric_diff = 0.0000000),
     tol = 10e-5
   )
+  expect_equal(
+    find_permuted_perf_metric(otu_mini_bin_results_glmnet$test_data %>% dplyr::as_tibble(),
+                              otu_mini_bin_results_glmnet$trained_model,
+                              "dx", caret::multiClassSummary,
+                              "AUC", TRUE, "Otu00009",
+                              seed = 2019
+    ),
+    c(perf_metric = 0.639105263, perf_metric_diff = 0.008263158),
+    tol = 10e-5
+  )
 })
+
+feat_imp <- structure(list(perf_metric = c(
+  0.639105263157895, 0.644236842105263,
+  0.631447368421053, 0.632236842105263, 0.596921052631579, 0.639526315789474,
+  0.639578947368421, 0.607657894736842, 0.643789473684211, 0.635605263157895
+), perf_metric_diff = c(
+  0.00826315789473686, 0.00313157894736845,
+  0.015921052631579, 0.0151315789473684, 0.0504473684210527, 0.00784210526315793,
+  0.00778947368421055, 0.0397105263157895, 0.00357894736842107,
+  0.0117631578947369
+), names = structure(c(
+  9L, 5L, 10L, 1L, 8L,
+  4L, 3L, 2L, 7L, 6L
+), .Label = c(
+  "Otu00001", "Otu00002", "Otu00003",
+  "Otu00004", "Otu00005", "Otu00006", "Otu00007", "Otu00008", "Otu00009",
+  "Otu00010"
+), class = "factor"), method = c(
+  "glmnet", "glmnet",
+  "glmnet", "glmnet", "glmnet", "glmnet", "glmnet", "glmnet", "glmnet",
+  "glmnet"
+), perf_metric_name = c(
+  "AUC", "AUC", "AUC", "AUC", "AUC",
+  "AUC", "AUC", "AUC", "AUC", "AUC"
+), seed = c(
+  2019, 2019, 2019,
+  2019, 2019, 2019, 2019, 2019, 2019, 2019
+)), class = "data.frame", row.names = c(
+  NA,
+  -10L
+))
 
 test_that("feature importances are correct", {
   expect_equal(
@@ -47,35 +88,38 @@ test_that("feature importances are correct", {
       seed = 2019,
       corr_thresh = 1
     ),
-    structure(list(perf_metric = c(
-      0.639105263157895, 0.644236842105263,
-      0.631447368421053, 0.632236842105263, 0.596921052631579, 0.639526315789474,
-      0.639578947368421, 0.607657894736842, 0.643789473684211, 0.635605263157895
-    ), perf_metric_diff = c(
-      0.00826315789473686, 0.00313157894736845,
-      0.015921052631579, 0.0151315789473684, 0.0504473684210527, 0.00784210526315793,
-      0.00778947368421055, 0.0397105263157895, 0.00357894736842107,
-      0.0117631578947369
-    ), names = structure(c(
-      9L, 5L, 10L, 1L, 8L,
-      4L, 3L, 2L, 7L, 6L
-    ), .Label = c(
-      "Otu00001", "Otu00002", "Otu00003",
-      "Otu00004", "Otu00005", "Otu00006", "Otu00007", "Otu00008", "Otu00009",
-      "Otu00010"
-    ), class = "factor"), method = c(
-      "glmnet", "glmnet",
-      "glmnet", "glmnet", "glmnet", "glmnet", "glmnet", "glmnet", "glmnet",
-      "glmnet"
-    ), perf_metric_name = c(
-      "AUC", "AUC", "AUC", "AUC", "AUC",
-      "AUC", "AUC", "AUC", "AUC", "AUC"
-    ), seed = c(
-      2019, 2019, 2019,
-      2019, 2019, 2019, 2019, 2019, 2019, 2019
-    )), class = "data.frame", row.names = c(
-      NA,
-      -10L
-    ))
+    feat_imp
+  )
+})
+test_that("feature importances are correct when tibbles used", {
+  expect_equal(
+    get_feature_importance(
+      otu_mini_bin_results_glmnet$trained_model,
+      otu_mini_bin_results_glmnet$trained_model$trainingData %>% dplyr::rename(dx = .outcome) %>% dplyr::as_tibble(),
+      otu_mini_bin_results_glmnet$test_data,
+      "dx",
+      caret::multiClassSummary,
+      "AUC",
+      TRUE,
+      "glmnet",
+      seed = 2019,
+      corr_thresh = 1
+    ),
+    feat_imp
+  )
+  expect_equal(
+    get_feature_importance(
+      otu_mini_bin_results_glmnet$trained_model,
+      otu_mini_bin_results_glmnet$trained_model$trainingData %>% dplyr::rename(dx = .outcome),
+      otu_mini_bin_results_glmnet$test_data %>% dplyr::as_tibble(),
+      "dx",
+      caret::multiClassSummary,
+      "AUC",
+      TRUE,
+      "glmnet",
+      seed = 2019,
+      corr_thresh = 1
+    ),
+    feat_imp
   )
 })


### PR DESCRIPTION
Fixes #225 by converting `test_data` to a `data.frame`. A better fix would be to refactor the code so it doesn't use base R subsetting.

We really should not use square brackets for subsetting. It causes problems when you subset a single column of a tibble and you expect it to return a vector, but it actually returns a tibble with one column. Use `dplyr::pull()` if you want a vector.