### PR TITLE
Clarify meaning of perf_metric_diff

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# development version
+
+- Made documentation improvements (#238).
+
 # mikropml 0.0.2
 
 - Fixed a test failure on Solaris.

--- a/R/feature_importance.R
+++ b/R/feature_importance.R
@@ -10,8 +10,9 @@
 #' @return Dataframe with performance metrics for when each feature (or group of
 #'   correlated features; `names`) is permuted (`perf_metric`), and differences
 #'   between test performance metric and permuted performance metric
-#'   (`perf_metric_diff`). The performance metric name (`perf_metric_name`) and
-#'   seed (`seed`) are also returned.
+#'   (`perf_metric_diff`; test minus permuted performance). Features with a
+#'   larger `perf_metric_diff` are more important. The performance metric name
+#'   (`perf_metric_name`) and seed (`seed`) are also returned.
 #'
 #' @examples
 #' \donttest{
@@ -81,8 +82,8 @@ get_feature_importance <- function(trained_model, train_data, test_data,
 #' @inheritParams run_ml
 #' @inheritParams get_feature_importance
 #'
-#' @return vector of mean permuted auc and mean difference between test and
-#'   permuted auc
+#' @return vector of mean permuted performance and mean difference between test
+#'   and permuted performance (test minus permuted performance)
 #' @noRd
 #' @author Begüm Topçuoğlu, \email{topcuoglu.begum@@gmail.com}
 #' @author Zena Lapp, \email{zenalapp@@umich.edu}

--- a/R/mikropml.R
+++ b/R/mikropml.R
@@ -1,6 +1,6 @@
 #' mikropml: User-Friendly R Package for Robust Machine Learning Pipelines
 #'
-#' `mikropml` implements robust machine learning pipelines using regression,
+#' `mikropml` implements supervised machine learning pipelines using regression,
 #' support vector machines, decision trees, random forest, or gradient-boosted trees.
 #' The main functions are `preprocess_data()` to process your data prior to
 #' running machine learning, and `run_ml()` to run machine learning.

--- a/R/run_ml.R
+++ b/R/run_ml.R
@@ -1,7 +1,7 @@
 #' Run the machine learning pipeline
 #'
 #' This function runs machine learning (ML), evaluates the best model,
-#' and optionally calculates feature importance using a robust framework
+#' and optionally calculates feature importance using the framework
 #' outlined in Topçuoğlu _et al._ 2020 ([doi:10.1128/mBio.00434-20](https://doi.org/10.1128/mBio.00434-20)).
 #' Required inputs are a dataframe with an outcome variable and other columns
 #' as features, as well as the ML method.

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -24,12 +24,14 @@ authors:
 reference:
 - title: Main
   desc: >
-    These functions provide all you need to build robust machine learning models.
+    The foundations for training machine learning models.
   contents:
   - mikropml
   - preprocess_data
   - run_ml
 - title: Plotting helpers
+  desc: >
+    Visualize performance to help you tune hyperparameters and choose model methods.
   contents:
   - starts_with('plot')
   - tidy_perf_data

--- a/man/get_feature_importance.Rd
+++ b/man/get_feature_importance.Rd
@@ -62,8 +62,9 @@ above or equal to \code{corr_thresh} (range \code{0} to \code{1}; default: \code
 Dataframe with performance metrics for when each feature (or group of
 correlated features; \code{names}) is permuted (\code{perf_metric}), and differences
 between test performance metric and permuted performance metric
-(\code{perf_metric_diff}). The performance metric name (\code{perf_metric_name}) and
-seed (\code{seed}) are also returned.
+(\code{perf_metric_diff}; test minus permuted performance). Features with a
+larger \code{perf_metric_diff} are more important. The performance metric name
+(\code{perf_metric_name}) and seed (\code{seed}) are also returned.
 }
 \description{
 Calculates feature importance using a trained model and test data. Requires

--- a/man/mikropml.Rd
+++ b/man/mikropml.Rd
@@ -5,7 +5,7 @@
 \alias{mikropml}
 \title{mikropml: User-Friendly R Package for Robust Machine Learning Pipelines}
 \description{
-\code{mikropml} implements robust machine learning pipelines using regression,
+\code{mikropml} implements supervised machine learning pipelines using regression,
 support vector machines, decision trees, random forest, or gradient-boosted trees.
 The main functions are \code{preprocess_data()} to process your data prior to
 running machine learning, and \code{run_ml()} to run machine learning.

--- a/man/run_ml.Rd
+++ b/man/run_ml.Rd
@@ -88,7 +88,7 @@ Named list with results:
 }
 \description{
 This function runs machine learning (ML), evaluates the best model,
-and optionally calculates feature importance using a robust framework
+and optionally calculates feature importance using the framework
 outlined in Topçuoğlu \emph{et al.} 2020 (\href{https://doi.org/10.1128/mBio.00434-20}{doi:10.1128/mBio.00434-20}).
 Required inputs are a dataframe with an outcome variable and other columns
 as features, as well as the ML method.

--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -317,8 +317,8 @@ results_imp$feature_importance
 
 There are several columns:
 
-1. `perf_metric`: The performance metric of the permuted feature.
-1. `perf_metric_diff`: The difference between the performance metric for the true and permuted data.
+1. `perf_metric`: The performance value of the permuted feature.
+1. `perf_metric_diff`: The difference between the performance for the true and permuted data (i.e. test performance minus permuted performance). Features with a larger `perf_metric_diff` are more important.
 1. `names`: The feature that was permuted.
 1. `method`: The ML method used.
 1. `perf_metric_name`: The peformance metric used.


### PR DESCRIPTION
## Issues
NA

## Change(s) made
- Clarified the meaning of `perf_metric_diff` in `get_feature_importance()` and the intro vignette.
- Snuck in minor changes to remove the term "robust" from docs (per JW's paper revisions).

## Checklist
- [x] Update `NEWS.md` if this includes any user-facing changes. ~Strikethrough~ if not applicable.
- [ ] The check workflow succeeds on your most recent commit.
