### PR TITLE
Don't convert outcome vectors to characters in preprocess_data()

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@
 
 (~Strikethrough~ any points that are not applicable.)
 
-- [ ] Write unit tests for any new functionality.
+- [ ] Write unit tests for any new functionality or bug fixes.
 - [ ] Update roxygen comments & vignettes if there are any API changes.
 - [ ] Update `NEWS.md` if this includes any user-facing changes. 
 - [ ] The check workflow succeeds on your most recent commit. **This is always required before the PR can be merged.**

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@
 
 - New correlation method option for feature importance (#267, @courtneyarmour).
     - The default is still "spearman", and now you can use other methods supported by `stats::cor` with the `corr_method` parameter: `get_feature_importance(corr_method = "pearson")`
-- There are now [video tutorials](https://youtube.com/playlist?list=PLmNrK_nkqBpKpzb9-vI4V7SdXC-jXEcmg) covering mikropml and other skills related to machine learning, created by @pschloss.
+- There are now [video tutorials](https://youtube.com/playlist?list=PLmNrK_nkqBpKpzb9-vI4V7SdXC-jXEcmg) covering mikropml and other skills related to machine learning, created by @pschloss (#270).
+- Fixed a bug where `preprocess_data()` converted the outcome column to a character vector (#273, @kelly-sovacool, @ecmaggioncalda).
 
 # mikropml 1.0.0
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -149,7 +149,10 @@ mutate_all_types <- function(dat) {
 #' dat$dx <- replace_spaces(dat$dx)
 #' dat
 replace_spaces <- function(x, new_char = "_") {
-  gsub(" ", new_char, x)
+  if (is.character(x)) {
+    x <- gsub(" ", new_char, x)
+  }
+  return(x)
 }
 
 #' Update progress if the progress bar is not `NULL`.

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -7,7 +7,7 @@ articles:
   parallel: parallel.html
   preprocess: preprocess.html
   tuning: tuning.html
-last_built: 2021-07-14T19:30Z
+last_built: 2021-08-05T17:57Z
 urls:
   reference: http://www.schlosslab.org/mikropml/reference
   article: http://www.schlosslab.org/mikropml/articles

--- a/docs/pull_request_template.html
+++ b/docs/pull_request_template.html
@@ -171,7 +171,7 @@
 <ul>
 <li>
 <input type="checkbox" disabled>
-Write unit tests for any new functionality.</li>
+Write unit tests for any new functionality or bug fixes.</li>
 <li>
 <input type="checkbox" disabled>
 Update roxygen comments &amp; vignettes if there are any API changes.</li>

--- a/docs/reference/get_perf_metric_fn.html
+++ b/docs/reference/get_perf_metric_fn.html
@@ -182,7 +182,7 @@
 #&gt;         data$obs &lt;- factor(data$obs, levels = lev)
 #&gt;     postResample(data[, "pred"], data[, "obs"])
 #&gt; }
-#&gt; &lt;bytecode: 0x7fabb3cc61d0&gt;
+#&gt; &lt;bytecode: 0x7f9e05f318c8&gt;
 #&gt; &lt;environment: namespace:caret&gt;</div><div class='input'><span class='fu'>get_perf_metric_fn</span><span class='op'>(</span><span class='st'>"binary"</span><span class='op'>)</span>
 </div><div class='output co'>#&gt; function (data, lev = NULL, model = NULL) 
 #&gt; {
@@ -239,7 +239,7 @@
 #&gt;     stats &lt;- stats[c(stat_list)]
 #&gt;     return(stats)
 #&gt; }
-#&gt; &lt;bytecode: 0x7fabcf4d8c68&gt;
+#&gt; &lt;bytecode: 0x7f9deea44478&gt;
 #&gt; &lt;environment: namespace:caret&gt;</div><div class='input'><span class='fu'>get_perf_metric_fn</span><span class='op'>(</span><span class='st'>"multiclass"</span><span class='op'>)</span>
 </div><div class='output co'>#&gt; function (data, lev = NULL, model = NULL) 
 #&gt; {
@@ -296,7 +296,7 @@
 #&gt;     stats &lt;- stats[c(stat_list)]
 #&gt;     return(stats)
 #&gt; }
-#&gt; &lt;bytecode: 0x7fabcf4d8c68&gt;
+#&gt; &lt;bytecode: 0x7f9deea44478&gt;
 #&gt; &lt;environment: namespace:caret&gt;</div></pre>
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">

--- a/tests/testthat/test-preprocess_data.R
+++ b/tests/testthat/test-preprocess_data.R
@@ -317,6 +317,22 @@ test_that("rm_missing_outcome works", {
   )
 })
 
+test_that("preprocess_data preserves numeric outcomes", {
+  test_df_int <- data.frame(outcome = 1:4, var1 = 1:4)
+  expect_warning(
+    expect_equal(
+      preprocess_data(test_df_int, "outcome")$dat_transformed$outcome,
+      test_df_int$outcome
+    ),
+    "Data is being considered numeric, but all outcome values are integers."
+  )
+  test_df_dbl <- data.frame(outcome = c(1.1, 2.2, 3.3, 4.4), var1 = 1:4)
+  expect_equal(
+    preprocess_data(test_df_dbl, "outcome")$dat_transformed$outcome,
+    test_df_dbl$outcome
+  )
+})
+
 test_that("change_to_num works", {
   expect_equal(
     change_to_num(dplyr::as_tibble(test_df[, 13])),

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -71,6 +71,13 @@ test_that("replace_spaces works", {
   )
 })
 
+test_that("replace_spaces() doesn't modify non-character vectors", {
+  x <- 1:3
+  expect_equal(replace_spaces(x), x)
+  y <- c(1.1, 2.2, 3.3)
+  expect_equal(replace_spaces(y), y)
+})
+
 test_that("pbtick() updates the progress bar", {
   f <- function() {
     pb <- progressr::progressor(steps = 5)


### PR DESCRIPTION
## Issues
- Resolves #272.

## Change(s) made
- `replaces_spaces()` naively assumed the input would be a character vector and also returned a character vector. It now returns non-character vectors without modification.
- Wrote unit tests for `preprocess_data()` and `replace_spaces()` to ensure that non-character outcome vectors would be preserved.

## Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] Write unit tests for any new functionality or bug fixes.
- ~[x] Update roxygen comments & vignettes if there are any API changes.~
- [x] Update `NEWS.md` if this includes any user-facing changes. 
- [ ] The check workflow succeeds on your most recent commit. **This is always required before the PR can be merged.**
