### PR TITLE
Add parameter for custom cross-validation schemes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # development version 
 
+- New parameter `cross_val` added to `run_ml()` allows users to define their own custom cross-validation scheme.
+
 # mikropml 1.1.1
 
 - Fixed bugs related to grouping correlated features (#276, @kelly-sovacool).


### PR DESCRIPTION
## Issues
- Partially address #182.

## Change(s) made
- Added `cross_val` parameter to `run_ml()` so users can use `caret::trainControl()` to define their own CV scheme.

## Checklist

(~Strikethrough~ any points that are not applicable.)

- [ ] Write unit tests for any new functionality or bug fixes.
- [ ] Update roxygen comments & vignettes if there are any API changes.
- [ ] Update `NEWS.md` if this includes any user-facing changes. 
- [ ] The check workflow succeeds on your most recent commit. **This is always required before the PR can be merged.**
