### PR TITLE
Depend on R >= 4.1.0 because randomForest does now

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -59,7 +59,7 @@ URL: https://www.schlosslab.org/mikropml/,
     https://github.com/SchlossLab/mikropml
 BugReports: https://github.com/SchlossLab/mikropml/issues
 Depends:
-    R (>= 2.10)
+    R (>= 4.1.0)
 Imports:
     caret,
     dplyr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # development version
 
+- mikropml now requires R version 4.1.0 or greater due to an update in the randomForest package (#292). 
+
 # mikropml 1.2.2
 
 This minor patch fixes a test failure on platforms with no long doubles.

--- a/docs/404.html
+++ b/docs/404.html
@@ -39,7 +39,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="http://www.schlosslab.org/mikropml/index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/CODE_OF_CONDUCT.html
+++ b/docs/CODE_OF_CONDUCT.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/CONTRIBUTING.html
+++ b/docs/CONTRIBUTING.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/LICENSE-text.html
+++ b/docs/LICENSE-text.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/LICENSE.html
+++ b/docs/LICENSE.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/SUPPORT.html
+++ b/docs/SUPPORT.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/articles/introduction.html
+++ b/docs/articles/introduction.html
@@ -40,7 +40,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/articles/paper.html
+++ b/docs/articles/paper.html
@@ -40,7 +40,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/articles/parallel.html
+++ b/docs/articles/parallel.html
@@ -40,7 +40,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/articles/preprocess.html
+++ b/docs/articles/preprocess.html
@@ -40,7 +40,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/articles/tuning.html
+++ b/docs/articles/tuning.html
@@ -40,7 +40,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -47,7 +47,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 
@@ -74,7 +74,7 @@
     </div>
 
     <div class="section level2">
-<h2 class="page-header" data-toc-text="1.2.2" id="mikropml-122">mikropml 1.2.2<a class="anchor" aria-label="anchor" href="#mikropml-122"></a></h2>
+<h2 class="page-header" data-toc-text="1.2.2" id="mikropml-122">mikropml 1.2.2<small>2022-02-03</small><a class="anchor" aria-label="anchor" href="#mikropml-122"></a></h2>
 <p>This minor patch fixes a test failure on platforms with no long doubles. The actual package code remains unchanged.</p>
 </div>
     <div class="section level2">

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -7,7 +7,7 @@ articles:
   parallel: parallel.html
   preprocess: preprocess.html
   tuning: tuning.html
-last_built: 2022-02-02T19:58Z
+last_built: 2022-02-16T00:02Z
 urls:
   reference: http://www.schlosslab.org/mikropml/reference
   article: http://www.schlosslab.org/mikropml/articles

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -7,7 +7,7 @@ articles:
   parallel: parallel.html
   preprocess: preprocess.html
   tuning: tuning.html
-last_built: 2022-02-16T00:02Z
+last_built: 2022-02-16T00:57Z
 urls:
   reference: http://www.schlosslab.org/mikropml/reference
   article: http://www.schlosslab.org/mikropml/articles

--- a/docs/pull_request_template.html
+++ b/docs/pull_request_template.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/calc_perf_metrics.html
+++ b/docs/reference/calc_perf_metrics.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/combine_hp_performance.html
+++ b/docs/reference/combine_hp_performance.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/define_cv.html
+++ b/docs/reference/define_cv.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/get_caret_processed_df.html
+++ b/docs/reference/get_caret_processed_df.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/get_feature_importance.html
+++ b/docs/reference/get_feature_importance.html
@@ -18,7 +18,7 @@ the future.apply package."><meta property="og:image" content="http://www.schloss
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/get_hp_performance.html
+++ b/docs/reference/get_hp_performance.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/get_hyperparams_list.html
+++ b/docs/reference/get_hyperparams_list.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/get_outcome_type.html
+++ b/docs/reference/get_outcome_type.html
@@ -19,7 +19,7 @@ multiclass if there are more than two outcomes."><meta property="og:image" conte
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/get_partition_indices.html
+++ b/docs/reference/get_partition_indices.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/get_perf_metric_fn.html
+++ b/docs/reference/get_perf_metric_fn.html
@@ -105,7 +105,7 @@
 <span class="r-out co"><span class="r-pr">#&gt;</span>         data$obs &lt;- factor(data$obs, levels = lev)</span>
 <span class="r-out co"><span class="r-pr">#&gt;</span>     postResample(data[, "pred"], data[, "obs"])</span>
 <span class="r-out co"><span class="r-pr">#&gt;</span> }</span>
-<span class="r-out co"><span class="r-pr">#&gt;</span> &lt;bytecode: 0x7f819825fa18&gt;</span>
+<span class="r-out co"><span class="r-pr">#&gt;</span> &lt;bytecode: 0x7fc3a9027900&gt;</span>
 <span class="r-out co"><span class="r-pr">#&gt;</span> &lt;environment: namespace:caret&gt;</span>
 <span class="r-in"><span class="fu">get_perf_metric_fn</span><span class="op">(</span><span class="st">"binary"</span><span class="op">)</span></span>
 <span class="r-out co"><span class="r-pr">#&gt;</span> function (data, lev = NULL, model = NULL) </span>
@@ -163,7 +163,7 @@
 <span class="r-out co"><span class="r-pr">#&gt;</span>     stats &lt;- stats[c(stat_list)]</span>
 <span class="r-out co"><span class="r-pr">#&gt;</span>     return(stats)</span>
 <span class="r-out co"><span class="r-pr">#&gt;</span> }</span>
-<span class="r-out co"><span class="r-pr">#&gt;</span> &lt;bytecode: 0x7f81ae1e3bd8&gt;</span>
+<span class="r-out co"><span class="r-pr">#&gt;</span> &lt;bytecode: 0x7fc3bcaf8da0&gt;</span>
 <span class="r-out co"><span class="r-pr">#&gt;</span> &lt;environment: namespace:caret&gt;</span>
 <span class="r-in"><span class="fu">get_perf_metric_fn</span><span class="op">(</span><span class="st">"multiclass"</span><span class="op">)</span></span>
 <span class="r-out co"><span class="r-pr">#&gt;</span> function (data, lev = NULL, model = NULL) </span>
@@ -221,7 +221,7 @@
 <span class="r-out co"><span class="r-pr">#&gt;</span>     stats &lt;- stats[c(stat_list)]</span>
 <span class="r-out co"><span class="r-pr">#&gt;</span>     return(stats)</span>
 <span class="r-out co"><span class="r-pr">#&gt;</span> }</span>
-<span class="r-out co"><span class="r-pr">#&gt;</span> &lt;bytecode: 0x7f81ae1e3bd8&gt;</span>
+<span class="r-out co"><span class="r-pr">#&gt;</span> &lt;bytecode: 0x7fc3bcaf8da0&gt;</span>
 <span class="r-out co"><span class="r-pr">#&gt;</span> &lt;environment: namespace:caret&gt;</span>
 </code></pre></div>
     </div>

--- a/docs/reference/get_perf_metric_fn.html
+++ b/docs/reference/get_perf_metric_fn.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 
@@ -105,7 +105,7 @@
 <span class="r-out co"><span class="r-pr">#&gt;</span>         data$obs &lt;- factor(data$obs, levels = lev)</span>
 <span class="r-out co"><span class="r-pr">#&gt;</span>     postResample(data[, "pred"], data[, "obs"])</span>
 <span class="r-out co"><span class="r-pr">#&gt;</span> }</span>
-<span class="r-out co"><span class="r-pr">#&gt;</span> &lt;bytecode: 0x7fd557dae010&gt;</span>
+<span class="r-out co"><span class="r-pr">#&gt;</span> &lt;bytecode: 0x7f819825fa18&gt;</span>
 <span class="r-out co"><span class="r-pr">#&gt;</span> &lt;environment: namespace:caret&gt;</span>
 <span class="r-in"><span class="fu">get_perf_metric_fn</span><span class="op">(</span><span class="st">"binary"</span><span class="op">)</span></span>
 <span class="r-out co"><span class="r-pr">#&gt;</span> function (data, lev = NULL, model = NULL) </span>
@@ -163,7 +163,7 @@
 <span class="r-out co"><span class="r-pr">#&gt;</span>     stats &lt;- stats[c(stat_list)]</span>
 <span class="r-out co"><span class="r-pr">#&gt;</span>     return(stats)</span>
 <span class="r-out co"><span class="r-pr">#&gt;</span> }</span>
-<span class="r-out co"><span class="r-pr">#&gt;</span> &lt;bytecode: 0x7fd56e4e91c8&gt;</span>
+<span class="r-out co"><span class="r-pr">#&gt;</span> &lt;bytecode: 0x7f81ae1e3bd8&gt;</span>
 <span class="r-out co"><span class="r-pr">#&gt;</span> &lt;environment: namespace:caret&gt;</span>
 <span class="r-in"><span class="fu">get_perf_metric_fn</span><span class="op">(</span><span class="st">"multiclass"</span><span class="op">)</span></span>
 <span class="r-out co"><span class="r-pr">#&gt;</span> function (data, lev = NULL, model = NULL) </span>
@@ -221,7 +221,7 @@
 <span class="r-out co"><span class="r-pr">#&gt;</span>     stats &lt;- stats[c(stat_list)]</span>
 <span class="r-out co"><span class="r-pr">#&gt;</span>     return(stats)</span>
 <span class="r-out co"><span class="r-pr">#&gt;</span> }</span>
-<span class="r-out co"><span class="r-pr">#&gt;</span> &lt;bytecode: 0x7fd56e4e91c8&gt;</span>
+<span class="r-out co"><span class="r-pr">#&gt;</span> &lt;bytecode: 0x7f81ae1e3bd8&gt;</span>
 <span class="r-out co"><span class="r-pr">#&gt;</span> &lt;environment: namespace:caret&gt;</span>
 </code></pre></div>
     </div>

--- a/docs/reference/get_perf_metric_name.html
+++ b/docs/reference/get_perf_metric_name.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/get_performance_tbl.html
+++ b/docs/reference/get_performance_tbl.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/get_tuning_grid.html
+++ b/docs/reference/get_tuning_grid.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/group_correlated_features.html
+++ b/docs/reference/group_correlated_features.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/mikropml.html
+++ b/docs/reference/mikropml.html
@@ -20,7 +20,7 @@ running machine learning, and run_ml() to run machine learning."><meta property=
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/otu_mini_bin.html
+++ b/docs/reference/otu_mini_bin.html
@@ -19,7 +19,7 @@ This is a subset of otu_small."><meta property="og:image" content="http://www.sc
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/otu_mini_bin_results_glmnet.html
+++ b/docs/reference/otu_mini_bin_results_glmnet.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/otu_mini_bin_results_rf.html
+++ b/docs/reference/otu_mini_bin_results_rf.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/otu_mini_bin_results_rpart2.html
+++ b/docs/reference/otu_mini_bin_results_rpart2.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/otu_mini_bin_results_svmRadial.html
+++ b/docs/reference/otu_mini_bin_results_svmRadial.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/otu_mini_bin_results_xgbTree.html
+++ b/docs/reference/otu_mini_bin_results_xgbTree.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/otu_mini_cont_results_glmnet.html
+++ b/docs/reference/otu_mini_cont_results_glmnet.html
@@ -20,7 +20,7 @@ as the outcome"><meta property="og:image" content="http://www.schlosslab.org/mik
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/otu_mini_cont_results_nocv.html
+++ b/docs/reference/otu_mini_cont_results_nocv.html
@@ -23,7 +23,7 @@ using a custom train control scheme that does not perform cross-validation"><met
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/otu_mini_cv.html
+++ b/docs/reference/otu_mini_cv.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/otu_mini_multi.html
+++ b/docs/reference/otu_mini_multi.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/otu_mini_multi_group.html
+++ b/docs/reference/otu_mini_multi_group.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/otu_mini_multi_results_glmnet.html
+++ b/docs/reference/otu_mini_multi_results_glmnet.html
@@ -20,7 +20,7 @@ multiclass outcomes"><meta property="og:image" content="http://www.schlosslab.or
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/otu_small.html
+++ b/docs/reference/otu_small.html
@@ -19,7 +19,7 @@ used in Topçuoğlu et al. 2020."><meta property="og:image" content="http://www.
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/plot_hp_performance.html
+++ b/docs/reference/plot_hp_performance.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/plot_model_performance.html
+++ b/docs/reference/plot_model_performance.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/preprocess_data.html
+++ b/docs/reference/preprocess_data.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/randomize_feature_order.html
+++ b/docs/reference/randomize_feature_order.html
@@ -107,10 +107,10 @@
 <span class="r-in">  a <span class="op">=</span> <span class="fl">4</span><span class="op">:</span><span class="fl">6</span>, b <span class="op">=</span> <span class="fl">7</span><span class="op">:</span><span class="fl">9</span>, c <span class="op">=</span> <span class="fl">10</span><span class="op">:</span><span class="fl">12</span>, d <span class="op">=</span> <span class="fl">13</span><span class="op">:</span><span class="fl">15</span></span>
 <span class="r-in"><span class="op">)</span></span>
 <span class="r-in"><span class="fu">randomize_feature_order</span><span class="op">(</span><span class="va">dat</span>, <span class="st">"outcome"</span><span class="op">)</span></span>
-<span class="r-out co"><span class="r-pr">#&gt;</span>   outcome  c b  d a</span>
-<span class="r-out co"><span class="r-pr">#&gt;</span> 1       1 10 7 13 4</span>
-<span class="r-out co"><span class="r-pr">#&gt;</span> 2       2 11 8 14 5</span>
-<span class="r-out co"><span class="r-pr">#&gt;</span> 3       3 12 9 15 6</span>
+<span class="r-out co"><span class="r-pr">#&gt;</span>   outcome b  c  d a</span>
+<span class="r-out co"><span class="r-pr">#&gt;</span> 1       1 7 10 13 4</span>
+<span class="r-out co"><span class="r-pr">#&gt;</span> 2       2 8 11 14 5</span>
+<span class="r-out co"><span class="r-pr">#&gt;</span> 3       3 9 12 15 6</span>
 </code></pre></div>
     </div>
   </div>

--- a/docs/reference/randomize_feature_order.html
+++ b/docs/reference/randomize_feature_order.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 
@@ -107,10 +107,10 @@
 <span class="r-in">  a <span class="op">=</span> <span class="fl">4</span><span class="op">:</span><span class="fl">6</span>, b <span class="op">=</span> <span class="fl">7</span><span class="op">:</span><span class="fl">9</span>, c <span class="op">=</span> <span class="fl">10</span><span class="op">:</span><span class="fl">12</span>, d <span class="op">=</span> <span class="fl">13</span><span class="op">:</span><span class="fl">15</span></span>
 <span class="r-in"><span class="op">)</span></span>
 <span class="r-in"><span class="fu">randomize_feature_order</span><span class="op">(</span><span class="va">dat</span>, <span class="st">"outcome"</span><span class="op">)</span></span>
-<span class="r-out co"><span class="r-pr">#&gt;</span>   outcome b a  d  c</span>
-<span class="r-out co"><span class="r-pr">#&gt;</span> 1       1 7 4 13 10</span>
-<span class="r-out co"><span class="r-pr">#&gt;</span> 2       2 8 5 14 11</span>
-<span class="r-out co"><span class="r-pr">#&gt;</span> 3       3 9 6 15 12</span>
+<span class="r-out co"><span class="r-pr">#&gt;</span>   outcome  c b  d a</span>
+<span class="r-out co"><span class="r-pr">#&gt;</span> 1       1 10 7 13 4</span>
+<span class="r-out co"><span class="r-pr">#&gt;</span> 2       2 11 8 14 5</span>
+<span class="r-out co"><span class="r-pr">#&gt;</span> 3       3 12 9 15 6</span>
 </code></pre></div>
     </div>
   </div>

--- a/docs/reference/reexports.html
+++ b/docs/reference/reexports.html
@@ -32,7 +32,7 @@ contr.ltfr
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/remove_singleton_columns.html
+++ b/docs/reference/remove_singleton_columns.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/replace_spaces.html
+++ b/docs/reference/replace_spaces.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/run_ml.html
+++ b/docs/reference/run_ml.html
@@ -23,7 +23,7 @@ See vignette('introduction') for more details."><meta property="og:image" conten
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/tidy_perf_data.html
+++ b/docs/reference/tidy_perf_data.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 

--- a/docs/reference/train_model.html
+++ b/docs/reference/train_model.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">mikropml</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.2.2.9000</span>
       </span>
     </div>
 


### PR DESCRIPTION
## Change(s) made
- Require R >= 4.1.0 because of [randomForest](https://cran.r-project.org/web/packages/randomForest/index.html)

## Checklist

(~Strikethrough~ any points that are not applicable.)

- ~[ ] Write unit tests for any new functionality or bug fixes.~
- ~[ ] Update docs if there are any API changes:~
  - ~[ ] roxygen comments~
  - ~[ ] vignettes~
- [x] Update `NEWS.md` if this includes any user-facing changes. 
- [x] The check workflow succeeds on your most recent commit. **This is always required before the PR can be merged.**
    - This fails on r-oldrel (4.0.5) because randomForest now requires R >= 4.1.0. It will start working again after a new R minor version gets released.