### PR TITLE
add corr_method and corr_thresh to preprocess_data

### DIFF
--- a/R/preprocess.R
+++ b/R/preprocess.R
@@ -7,6 +7,9 @@
 #'   no normalization).
 #' @param remove_var Whether to remove variables with near-zero variance
 #'   (`'nzv'`; default), zero variance (`'zv'`), or none (`NULL`).
+#' @param corr_method method used to correlate features, described in
+#' [stats::cor()] 
+#' @param corr_thresh lower threshold used to collapse correlated features
 #' @param collapse_corr_feats Whether to keep only one of perfectly correlated
 #'   features.
 #' @param to_numeric Whether to change features to numeric where possible.
@@ -59,6 +62,8 @@
 preprocess_data <- function(dataset, outcome_colname,
                             method = c("center", "scale"),
                             remove_var = "nzv", collapse_corr_feats = TRUE,
+                            corr_method = "spearman",
+                            corr_thresh = 1,
                             to_numeric = TRUE, group_neg_corr = TRUE,
                             prefilter_threshold = 1) {
   progbar <- NULL
@@ -116,6 +121,8 @@ preprocess_data <- function(dataset, outcome_colname,
       pbtick(progbar)
     }
     feats_and_grps <- collapse_correlated_features(processed_feats,
+                                                   corr_method = corr_method, 
+                                                   corr_thresh = corr_thresh,
       group_neg_corr,
       progbar = progbar
     )
@@ -488,7 +495,10 @@ get_caret_dummyvars_df <- function(features, full_rank = FALSE, progbar = NULL) 
 #' \dontrun{
 #' collapse_correlated_features(mikropml::otu_small[, 2:ncol(otu_small)])
 #' }
-collapse_correlated_features <- function(features, group_neg_corr = TRUE, progbar = NULL) {
+collapse_correlated_features <- function(features, group_neg_corr = TRUE, 
+                                         corr_method = corr_method, 
+                                         corr_thresh = corr_thresh,
+                                         progbar = NULL) {
   feats_nocorr <- features
   grp_feats <- NULL
   if (!is.null(features)) {
@@ -505,6 +515,8 @@ collapse_correlated_features <- function(features, group_neg_corr = TRUE, progba
     }
     if (ncol(features) != 1) {
       corr_feats <- group_correlated_features(features,
+                                              corr_method = corr_method, 
+                                              corr_thresh = corr_thresh,
         group_neg_corr = group_neg_corr
       )
       corr_cols <- gsub("\\|.*", "", corr_feats)

--- a/man/collapse_correlated_features.Rd
+++ b/man/collapse_correlated_features.Rd
@@ -4,13 +4,25 @@
 \alias{collapse_correlated_features}
 \title{Collapse correlated features}
 \usage{
-collapse_correlated_features(features, group_neg_corr = TRUE, progbar = NULL)
+collapse_correlated_features(
+  features,
+  group_neg_corr = TRUE,
+  corr_method = corr_method,
+  corr_thresh = corr_thresh,
+  progbar = NULL
+)
 }
 \arguments{
 \item{features}{dataframe of features for machine learning}
 
 \item{group_neg_corr}{Whether to group negatively correlated features
 together (e.g. c(0,1) and c(1,0)).}
+
+\item{corr_method}{correlation method. options or the same as those supported
+by \code{stats::cor}: spearman, pearson, kendall. (default: spearman)}
+
+\item{corr_thresh}{For feature importance, group correlations
+above or equal to \code{corr_thresh} (range \code{0} to \code{1}; default: \code{1}).}
 
 \item{progbar}{optional progress bar (default: \code{NULL})}
 }

--- a/man/mikropml-package.Rd
+++ b/man/mikropml-package.Rd
@@ -48,7 +48,7 @@ Useful links:
 
 Authors:
 \itemize{
-  \item Begüm Topçuoğlu \email{topcuoglu.begum@gmail.com} (\href{https://orcid.org/0000-0003-3140-537X}{ORCID})
+  \item Begüm Topçuoglu \email{topcuoglu.begum@gmail.com} (\href{https://orcid.org/0000-0003-3140-537X}{ORCID})
   \item Zena Lapp \email{zenalapp@umich.edu} (\href{https://orcid.org/0000-0003-4674-2176}{ORCID})
   \item Evan Snitkin (\href{https://orcid.org/0000-0001-8409-278X}{ORCID})
   \item Jenna Wiens (\href{https://orcid.org/0000-0002-1057-7722}{ORCID})

--- a/man/preprocess_data.Rd
+++ b/man/preprocess_data.Rd
@@ -10,6 +10,8 @@ preprocess_data(
   method = c("center", "scale"),
   remove_var = "nzv",
   collapse_corr_feats = TRUE,
+  corr_method = "spearman",
+  corr_thresh = 1,
   to_numeric = TRUE,
   group_neg_corr = TRUE,
   prefilter_threshold = 1
@@ -30,6 +32,11 @@ no normalization).}
 
 \item{collapse_corr_feats}{Whether to keep only one of perfectly correlated
 features.}
+
+\item{corr_method}{method used to correlate features, described in
+\code{\link[stats:cor]{stats::cor()}}}
+
+\item{corr_thresh}{lower threshold used to collapse correlated features}
 
 \item{to_numeric}{Whether to change features to numeric where possible.}
 

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -19,6 +19,6 @@ below to see their documentation.
 
   \item{dplyr}{\code{\link[dplyr:reexports]{\%>\%}}}
 
-  \item{rlang}{\code{\link[rlang:dyn-dots]{:=}}, \code{\link[rlang:injection-operator]{!!}}, \code{\link[rlang:dot-data]{.data}}}
+  \item{rlang}{\code{\link[rlang:injection-operator]{!!}}, \code{\link[rlang:dot-data]{.data}}, \code{\link[rlang:dyn-dots]{:=}}}
 }}
 


### PR DESCRIPTION
## Change(s) made

- I Added two new arguments to the function `preprocess_data`: corr_method and corr_threshold. I modified the docs of the function accordingly. This gives more flexibility to users.

Note that I had troubles installing the package propr. I'll look deeper into it to implement a new argument for user-defines correlation functions.

## Issues

- Resolves #350 .

## Checklist

(~Strikethrough~ any points that are not applicable.)

- [ ] Write unit tests for any new functionality or bug fixes.
- [ ] Update docs if there are any API changes:
  - [ ] roxygen comments
  - [ ] vignettes
- [ ] Update `NEWS.md` if this includes any user-facing changes.
- [ ] The check workflow succeeds on your most recent commit. **This is always required before the PR can be merged.**
